### PR TITLE
added a calibrate method

### DIFF
--- a/__tests__/RICMiniHCLC.test.ts
+++ b/__tests__/RICMiniHCLC.test.ts
@@ -8,7 +8,7 @@ test('HDLC simple encode', () => {
     const encodedBuf = hdlc.encode(new Uint8Array([72, 101, 108, 108, 111]));
     // console.log(RICUtils.bufferToHex(encodedBuf));
     expect(encodedBuf).toEqual(new Uint8Array([
-        hdlc.FRAME_BOUNDARY_OCTET,
+        hdlc["FRAME_BOUNDARY_OCTET"],
         72,
         101,
         108,
@@ -16,7 +16,7 @@ test('HDLC simple encode', () => {
         111,
         0xda,
         0xda,
-        hdlc.FRAME_BOUNDARY_OCTET,
+        hdlc["FRAME_BOUNDARY_OCTET"],
     ]));
 });
 
@@ -25,7 +25,7 @@ test('HDLC simple decode', () => {
 
     const testMsg = new Uint8Array(
         [
-            hdlc.FRAME_BOUNDARY_OCTET,
+            hdlc["FRAME_BOUNDARY_OCTET"],
             'H'.charCodeAt(0),
             'e'.charCodeAt(0),
             'l'.charCodeAt(0),
@@ -33,7 +33,7 @@ test('HDLC simple decode', () => {
             'o'.charCodeAt(0),
             0xda,
             0xda,
-            hdlc.FRAME_BOUNDARY_OCTET,
+            hdlc["FRAME_BOUNDARY_OCTET"],
         ]);
 
     let frameReceived: Uint8Array = new Uint8Array(0);
@@ -42,7 +42,7 @@ test('HDLC simple decode', () => {
         frameReceived = rxFrame;
     }
 
-    hdlc.onRxFrame = onHDLCFrame.bind(this);
+    hdlc["onRxFrame"] = onHDLCFrame.bind(this);
 
     hdlc.addRxBytes(testMsg);
 

--- a/src/RICSystem.ts
+++ b/src/RICSystem.ts
@@ -48,19 +48,6 @@ export default class RICSystem {
   // Calibration info
   private _calibInfo: RICCalibInfo | null = null;
 
-  // Joint names
-  private _jointNames = {
-    LeftHip: "LeftHip",
-    LeftTwist: "LeftTwist",
-    LeftKnee: "LeftKnee",
-    RightHip: "RightHip",
-    RightTwist: "RightTwist",
-    RightKnee: "RightKnee",
-    LeftArm: "LeftArm",
-    RightArm: "RightArm",
-    Eyes: "Eyes",
-  };
-
   // WiFi connection info
   private _ricWifiConnStatus: RICWifiConnStatus = new RICWifiConnStatus();
   private _defaultWiFiHostname = "Marty";
@@ -177,35 +164,18 @@ export default class RICSystem {
   }
   // Mark: Calibration -----------------------------------------------------------------------------------------
 
-  async calibrate(cmd: string, joints: string) {
+  async calibrate(cmd: string, jointList: Array<string>, jointNames: {[key: string]: string}) {
     let overallResult = true;
     if (cmd === "set") {
-      // Make a list of joints to set calibration on
-      const jointList: Array<string> = new Array<string>();
-      if (joints === "legs") {
-        jointList.push(this._jointNames.LeftHip);
-        jointList.push(this._jointNames.LeftTwist);
-        jointList.push(this._jointNames.LeftKnee);
-        jointList.push(this._jointNames.RightHip);
-        jointList.push(this._jointNames.RightTwist);
-        jointList.push(this._jointNames.RightKnee);
-      } else if (joints === "arms") {
-        jointList.push(this._jointNames.LeftArm);
-        jointList.push(this._jointNames.RightArm);
-      }
-      if (joints === "eyes") {
-        jointList.push(this._jointNames.Eyes);
-      }
-
       // Set calibration
       for (const jnt of jointList) {
         try {
           // Set calibration on joint
           const cmdUrl = "calibrate/set/" + jnt;
-          const rslt = await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
+          const rsl = await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
             cmdUrl
           );
-          if (rslt.rslt != "ok") overallResult = false;
+          if (rsl.rslt != "ok") overallResult = false;
         } catch (error) {
           console.log(`calibrate failed on joint ${jnt}`, error);
         }
@@ -216,14 +186,14 @@ export default class RICSystem {
       }
 
       // ensure all joints are enabled
-      for (const jnt in this._jointNames) {
+      for (const jnt in jointNames) {
         try {
           // enable joint
           const cmdUrl = "servo/" + jnt + "/enable/1";
-          const rslt = await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
+          const rsl = await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
             cmdUrl
           );
-          if (rslt.rslt != "ok") overallResult = false;
+          if (rsl.rslt != "ok") overallResult = false;
         } catch (error) {
           console.log(`enable failed on joint ${jnt}`, error);
         }

--- a/src/RICSystem.ts
+++ b/src/RICSystem.ts
@@ -8,14 +8,28 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-import { RICSysModInfoWiFi, RICWifiConnState, RICWifiConnStatus } from './RICWifiTypes';
+import {
+  RICSysModInfoWiFi,
+  RICWifiConnState,
+  RICWifiConnStatus,
+} from "./RICWifiTypes";
 import RICAddOnManager from "./RICAddOnManager";
-import RICLog from "./RICLog"
+import RICLog from "./RICLog";
 import RICMsgHandler from "./RICMsgHandler";
-import { RICAddOnList, RICCalibInfo, RICFileList, RICFriendlyName, RICHWElem, RICHWElemList, RICOKFail, RICReportMsg, RICSysModInfoBLEMan, RICSystemInfo } from "./RICTypes";
+import {
+  RICAddOnList,
+  RICCalibInfo,
+  RICFileList,
+  RICFriendlyName,
+  RICHWElem,
+  RICHWElemList,
+  RICOKFail,
+  RICReportMsg,
+  RICSysModInfoBLEMan,
+  RICSystemInfo,
+} from "./RICTypes";
 
 export default class RICSystem {
-
   // Message handler
   private _ricMsgHandler: RICMsgHandler;
 
@@ -34,9 +48,22 @@ export default class RICSystem {
   // Calibration info
   private _calibInfo: RICCalibInfo | null = null;
 
+  // Joint names
+  private _jointNames = {
+    LeftHip: "LeftHip",
+    LeftTwist: "LeftTwist",
+    LeftKnee: "LeftKnee",
+    RightHip: "RightHip",
+    RightTwist: "RightTwist",
+    RightKnee: "RightKnee",
+    LeftArm: "LeftArm",
+    RightArm: "RightArm",
+    Eyes: "Eyes",
+  };
+
   // WiFi connection info
   private _ricWifiConnStatus: RICWifiConnStatus = new RICWifiConnStatus();
-  private _defaultWiFiHostname = 'Marty';
+  private _defaultWiFiHostname = "Marty";
   private _maxSecsToWaitForWiFiConn = 20;
 
   /**
@@ -51,7 +78,7 @@ export default class RICSystem {
 
   /**
    * getFriendlyName
-   * 
+   *
    * @returns friendly name
    */
   getFriendlyName(): RICFriendlyName | null {
@@ -68,25 +95,24 @@ export default class RICSystem {
     this._addOnManager.clear();
     this._calibInfo = null;
     this._ricFriendlyName = null;
-    RICLog.debug('RICSystem information invalidated');
+    RICLog.debug("RICSystem information invalidated");
   }
 
   /**
    *  getSystemInfo - get system info
    * @returns Promise<RICSystemInfo>
-   *  
+   *
    */
   async retrieveInfo(): Promise<boolean> {
-
     // Get system info
     RICLog.debug(`RICSystem retrieveInfo getting system info`);
     try {
       await this.getRICSystemInfo(true);
       RICLog.debug(
-        `retrieveInfo - RIC Version ${this._systemInfo?.SystemVersion}`,
+        `retrieveInfo - RIC Version ${this._systemInfo?.SystemVersion}`
       );
     } catch (error) {
-      RICLog.warn('retrieveInfo - frailed to get version ' + error);
+      RICLog.warn("retrieveInfo - frailed to get version " + error);
       return false;
     }
 
@@ -94,7 +120,7 @@ export default class RICSystem {
     try {
       await this.getRICName();
     } catch (error) {
-      RICLog.warn('retrieveInfo - failed to get RIC name ' + error);
+      RICLog.warn("retrieveInfo - failed to get RIC name " + error);
       return false;
     }
 
@@ -102,7 +128,7 @@ export default class RICSystem {
     try {
       await this.getRICCalibInfo(true);
     } catch (error) {
-      RICLog.warn('retrieveInfo - failed to get calib info ' + error);
+      RICLog.warn("retrieveInfo - failed to get calib info " + error);
       return false;
     }
 
@@ -110,15 +136,15 @@ export default class RICSystem {
     try {
       await this.getWiFiConnStatus();
     } catch (error) {
-      RICLog.warn('retrieveInfo - failed to get WiFi Status ' + error);
+      RICLog.warn("retrieveInfo - failed to get WiFi Status " + error);
       return false;
     }
-    
+
     // Get HWElems (connected to RIC)
     try {
       await this.getHWElemList();
     } catch (error) {
-      RICLog.warn('retrieveInfo - failed to get HWElems ' + error);
+      RICLog.warn("retrieveInfo - failed to get HWElems " + error);
       return false;
     }
 
@@ -136,14 +162,80 @@ export default class RICSystem {
       return this._systemInfo;
     }
     try {
-      this._systemInfo = await this._ricMsgHandler.sendRICRESTURL<RICSystemInfo>('v');
-      RICLog.debug('getRICSystemInfo returned ' + JSON.stringify(this._systemInfo));
+      this._systemInfo = await this._ricMsgHandler.sendRICRESTURL<
+        RICSystemInfo
+      >("v");
+      RICLog.debug(
+        "getRICSystemInfo returned " + JSON.stringify(this._systemInfo)
+      );
       this._systemInfo.validMs = Date.now();
       return this._systemInfo;
     } catch (error) {
       RICLog.debug(`getRICSystemInfo Failed to get version ${error}`);
       return new RICSystemInfo();
     }
+  }
+  // Mark: Calibration -----------------------------------------------------------------------------------------
+
+  async calibrate(cmd: string, joints: string) {
+    let overallResult = true;
+    if (cmd === "set") {
+      // Make a list of joints to set calibration on
+      const jointList: Array<string> = new Array<string>();
+      if (joints === "legs") {
+        jointList.push(this._jointNames.LeftHip);
+        jointList.push(this._jointNames.LeftTwist);
+        jointList.push(this._jointNames.LeftKnee);
+        jointList.push(this._jointNames.RightHip);
+        jointList.push(this._jointNames.RightTwist);
+        jointList.push(this._jointNames.RightKnee);
+      } else if (joints === "arms") {
+        jointList.push(this._jointNames.LeftArm);
+        jointList.push(this._jointNames.RightArm);
+      }
+      if (joints === "eyes") {
+        jointList.push(this._jointNames.Eyes);
+      }
+
+      // Set calibration
+      for (const jnt of jointList) {
+        try {
+          // Set calibration on joint
+          const cmdUrl = "calibrate/set/" + jnt;
+          const rslt = await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
+            cmdUrl
+          );
+          if (rslt.rslt != "ok") overallResult = false;
+        } catch (error) {
+          console.log(`calibrate failed on joint ${jnt}`, error);
+        }
+
+        // Wait as writing to flash blocks servo access
+        // as of v0.0.113 of firmware, the pause is no longer required
+        //await new Promise(resolve => setTimeout(resolve, 3000));
+      }
+
+      // ensure all joints are enabled
+      for (const jnt in this._jointNames) {
+        try {
+          // enable joint
+          const cmdUrl = "servo/" + jnt + "/enable/1";
+          const rslt = await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
+            cmdUrl
+          );
+          if (rslt.rslt != "ok") overallResult = false;
+        } catch (error) {
+          console.log(`enable failed on joint ${jnt}`, error);
+        }
+      }
+
+      // Result
+      console.log("Set calibration flag to true");
+      const rslt = new RICOKFail();
+      rslt.set(overallResult);
+      return rslt;
+    }
+    return false;
   }
 
   /**
@@ -157,8 +249,10 @@ export default class RICSystem {
       return this._calibInfo;
     }
     try {
-      this._calibInfo = await this._ricMsgHandler.sendRICRESTURL<RICCalibInfo>('calibrate');
-      RICLog.debug('getRICCalibInfo returned ' + this._calibInfo);
+      this._calibInfo = await this._ricMsgHandler.sendRICRESTURL<RICCalibInfo>(
+        "calibrate"
+      );
+      RICLog.debug("getRICCalibInfo returned " + this._calibInfo);
       this._calibInfo.validMs = Date.now();
       return this._calibInfo;
     } catch (error) {
@@ -176,14 +270,22 @@ export default class RICSystem {
    */
   async setRICName(newName: string): Promise<boolean> {
     try {
-      this._ricFriendlyName = await this._ricMsgHandler.sendRICRESTURL<RICFriendlyName>(`friendlyname/${newName}`);
+      this._ricFriendlyName = await this._ricMsgHandler.sendRICRESTURL<
+        RICFriendlyName
+      >(`friendlyname/${newName}`);
       if (this._ricFriendlyName) {
         this._ricFriendlyName.friendlyNameIsSet = false;
         this._ricFriendlyName.validMs = Date.now();
-        if (this._ricFriendlyName && this._ricFriendlyName.rslt && (this._ricFriendlyName.rslt.toLowerCase() === 'ok')) {
+        if (
+          this._ricFriendlyName &&
+          this._ricFriendlyName.rslt &&
+          this._ricFriendlyName.rslt.toLowerCase() === "ok"
+        ) {
           this._ricFriendlyName.friendlyNameIsSet = true;
         }
-        RICLog.debug('setRICName returned ' + JSON.stringify(this._ricFriendlyName));
+        RICLog.debug(
+          "setRICName returned " + JSON.stringify(this._ricFriendlyName)
+        );
         return true;
       }
       return true;
@@ -201,14 +303,25 @@ export default class RICSystem {
    */
   async getRICName(): Promise<RICFriendlyName> {
     try {
-      this._ricFriendlyName = await this._ricMsgHandler.sendRICRESTURL<RICFriendlyName>('friendlyname');
-      if (this._ricFriendlyName && this._ricFriendlyName.rslt && (this._ricFriendlyName.rslt === 'ok')) {
-        this._ricFriendlyName.friendlyNameIsSet = (this._ricFriendlyName.friendlyNameIsSet ? true : false);
+      this._ricFriendlyName = await this._ricMsgHandler.sendRICRESTURL<
+        RICFriendlyName
+      >("friendlyname");
+      if (
+        this._ricFriendlyName &&
+        this._ricFriendlyName.rslt &&
+        this._ricFriendlyName.rslt === "ok"
+      ) {
+        this._ricFriendlyName.friendlyNameIsSet = this._ricFriendlyName
+          .friendlyNameIsSet
+          ? true
+          : false;
       } else {
         this._ricFriendlyName.friendlyNameIsSet = false;
       }
       this._ricFriendlyName.validMs = Date.now();
-      RICLog.debug("Friendly name set is: " + JSON.stringify(this._ricFriendlyName));
+      RICLog.debug(
+        "Friendly name set is: " + JSON.stringify(this._ricFriendlyName)
+      );
       return this._ricFriendlyName;
     } catch (error) {
       return new RICFriendlyName();
@@ -223,14 +336,18 @@ export default class RICSystem {
    */
   async getHWElemList(): Promise<RICHWElemList> {
     try {
-      const ricHWList = await this._ricMsgHandler.sendRICRESTURL<RICHWElemList>('hwstatus');
-      RICLog.debug('getHWElemList returned ' + JSON.stringify(ricHWList));
+      const ricHWList = await this._ricMsgHandler.sendRICRESTURL<RICHWElemList>(
+        "hwstatus"
+      );
+      RICLog.debug("getHWElemList returned " + JSON.stringify(ricHWList));
       this._hwElems = ricHWList.hw;
       this._addOnManager.setHWElems(this._hwElems);
 
       const reports: Array<RICReportMsg> = [];
       // add callback to subscribe to report messages
-      this._ricMsgHandler.reportMsgCallbacksSet("getHWElemCB", function (report: RICReportMsg) {
+      this._ricMsgHandler.reportMsgCallbacksSet("getHWElemCB", function (
+        report: RICReportMsg
+      ) {
         reports.push(report);
         RICLog.debug(`getHWElemCB Report callback ${JSON.stringify(report)}`);
       });
@@ -265,8 +382,10 @@ export default class RICSystem {
    */
   async getAddOnList(): Promise<RICAddOnList> {
     try {
-      const addOnList = await this._ricMsgHandler.sendRICRESTURL<RICAddOnList>('addon/list');
-      RICLog.debug('getAddOnList returned ' + addOnList);
+      const addOnList = await this._ricMsgHandler.sendRICRESTURL<RICAddOnList>(
+        "addon/list"
+      );
+      RICLog.debug("getAddOnList returned " + addOnList);
       return addOnList;
     } catch (error) {
       RICLog.debug(`getAddOnList Failed to get list of add-ons ${error}`);
@@ -282,8 +401,10 @@ export default class RICSystem {
    */
   async getFileList(): Promise<RICFileList> {
     try {
-      const ricFileList = await this._ricMsgHandler.sendRICRESTURL<RICFileList>('filelist');
-      RICLog.debug('getFileList returned ' + ricFileList);
+      const ricFileList = await this._ricMsgHandler.sendRICRESTURL<RICFileList>(
+        "filelist"
+      );
+      RICLog.debug("getFileList returned " + ricFileList);
       return ricFileList;
     } catch (error) {
       RICLog.debug(`getFileList Failed to get file list ${error}`);
@@ -303,13 +424,13 @@ export default class RICSystem {
     try {
       // Format the paramList as query string
       const paramEntries = Object.entries(params);
-      let paramQueryStr = '';
+      let paramQueryStr = "";
       for (const param of paramEntries) {
-        if (paramQueryStr.length > 0) paramQueryStr += '&';
-        paramQueryStr += param[0] + '=' + param[1];
+        if (paramQueryStr.length > 0) paramQueryStr += "&";
+        paramQueryStr += param[0] + "=" + param[1];
       }
       // Format the url to send
-      if (paramQueryStr.length > 0) commandName += '?' + paramQueryStr;
+      if (paramQueryStr.length > 0) commandName += "?" + paramQueryStr;
       return await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(commandName);
     } catch (error) {
       RICLog.debug(`runCommand failed ${error}`);
@@ -318,26 +439,28 @@ export default class RICSystem {
   }
 
   /**
-   * 
+   *
    * Get BLEMan sysmod info
-   * 
+   *
    * @returns RICSysModInfoBLEMan
-   * 
+   *
    */
   async getSysModInfoBLEMan(): Promise<RICSysModInfoBLEMan | null> {
     try {
       // Get SysMod Info
-      const bleInfo = await this._ricMsgHandler.sendRICRESTURL<RICSysModInfoBLEMan>('sysmodinfo/BLEMan');
+      const bleInfo = await this._ricMsgHandler.sendRICRESTURL<
+        RICSysModInfoBLEMan
+      >("sysmodinfo/BLEMan");
 
       // Debug
       RICLog.debug(
-        `getSysModInfoBLEMan rslt ${bleInfo.rslt} isConn ${bleInfo.isConn} paused ${bleInfo.isAdv} txBPS ${bleInfo.txBPS} rxBPS ${bleInfo.rxBPS}`,
+        `getSysModInfoBLEMan rslt ${bleInfo.rslt} isConn ${bleInfo.isConn} paused ${bleInfo.isAdv} txBPS ${bleInfo.txBPS} rxBPS ${bleInfo.rxBPS}`
       );
 
       // Check for test rate
       if ("tBPS" in bleInfo) {
         RICLog.debug(
-          `getSysModInfoBLEMan testMsgs ${bleInfo.tM} testBytes ${bleInfo.tB} testRateBytesPS ${bleInfo.tBPS}`,
+          `getSysModInfoBLEMan testMsgs ${bleInfo.tM} testBytes ${bleInfo.tB} testRateBytesPS ${bleInfo.tBPS}`
         );
       }
 
@@ -360,8 +483,8 @@ export default class RICSystem {
       return this._defaultWiFiHostname;
     }
     let hostname = friendlyName.friendlyName;
-    hostname = hostname?.replace(/ /g, '-');
-    hostname = hostname.replace(/\W+/g, '');
+    hostname = hostname?.replace(/ /g, "-");
+    hostname = hostname.replace(/\W+/g, "");
     return hostname;
   }
 
@@ -374,14 +497,16 @@ export default class RICSystem {
   async getWiFiConnStatus(): Promise<boolean | null> {
     try {
       // Get status
-      const ricSysModInfoWiFi = await this._ricMsgHandler.sendRICRESTURL<RICSysModInfoWiFi>('sysmodinfo/NetMan');
+      const ricSysModInfoWiFi = await this._ricMsgHandler.sendRICRESTURL<
+        RICSysModInfoWiFi
+      >("sysmodinfo/NetMan");
 
       RICLog.debug(
-        `wifiConnStatus rslt ${ricSysModInfoWiFi.rslt} isConn ${ricSysModInfoWiFi.isConn} paused ${ricSysModInfoWiFi.isPaused}`,
+        `wifiConnStatus rslt ${ricSysModInfoWiFi.rslt} isConn ${ricSysModInfoWiFi.isConn} paused ${ricSysModInfoWiFi.isPaused}`
       );
 
       // Check status indicates WiFi connected
-      if (ricSysModInfoWiFi.rslt === 'ok') {
+      if (ricSysModInfoWiFi.rslt === "ok") {
         this._ricWifiConnStatus.connState =
           ricSysModInfoWiFi.isConn !== 0
             ? RICWifiConnState.WIFI_CONN_CONNECTED
@@ -417,9 +542,9 @@ export default class RICSystem {
   async pauseWifiConnection(pause: boolean): Promise<boolean> {
     try {
       if (pause) {
-        await this._ricMsgHandler.sendRICRESTURL<RICOKFail>('wifipause/pause');
+        await this._ricMsgHandler.sendRICRESTURL<RICOKFail>("wifipause/pause");
       } else {
-        await this._ricMsgHandler.sendRICRESTURL<RICOKFail>('wifipause/resume');
+        await this._ricMsgHandler.sendRICRESTURL<RICOKFail>("wifipause/resume");
       }
     } catch (error) {
       RICLog.debug(`wifiConnect wifi pause ${error}`);
@@ -441,10 +566,20 @@ export default class RICSystem {
 
     // Issue the command to connect WiFi
     try {
-      const RICRESTURL_wifiCredentials = 'w/' + ssid + '/' + password + '/' + this._getHostnameFromFriendlyName();
-      RICLog.debug(`wifiConnect attempting to connect to wifi ${RICRESTURL_wifiCredentials}`);
+      const RICRESTURL_wifiCredentials =
+        "w/" +
+        ssid +
+        "/" +
+        password +
+        "/" +
+        this._getHostnameFromFriendlyName();
+      RICLog.debug(
+        `wifiConnect attempting to connect to wifi ${RICRESTURL_wifiCredentials}`
+      );
 
-      await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(RICRESTURL_wifiCredentials);
+      await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(
+        RICRESTURL_wifiCredentials
+      );
     } catch (error) {
       RICLog.debug(`wifiConnect failed ${error}`);
       return false;
@@ -457,7 +592,7 @@ export default class RICSystem {
       timeoutCount++
     ) {
       // Wait a little before checking
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
 
       // Get status info
       const connStat = await this.getWiFiConnStatus();
@@ -479,7 +614,7 @@ export default class RICSystem {
     try {
       RICLog.debug(`wifiDisconnect clearing wifi info`);
 
-      await this._ricMsgHandler.sendRICRESTURL<RICOKFail>('wc');
+      await this._ricMsgHandler.sendRICRESTURL<RICOKFail>("wc");
       this.getWiFiConnStatus();
       return true;
     } catch (error) {


### PR DESCRIPTION
Added a `calibrate` method in RICSystem. This method is used when the user wants to calibrate eyes/legs/arms.
I decided to add the method in RICSystem because there were more calibration-related work there, such as the `getRICCalibInfo` method.

I also changed the RICMiniHCLC.test.ts --lint and typescript were complaining about accessing private properties of the RICMiniHDLC class. A hack-ish way to overcome this is to use array access [] like so:   instead of className.property,  use className["property"]. This is a way to access private members without loosing type safety.