### PR TITLE
Ensure audio streaming finishes starting before allowing a new stream to start

### DIFF
--- a/src/RICConnector.ts
+++ b/src/RICConnector.ts
@@ -506,6 +506,10 @@ export default class RICConnector {
     }
   }
 
+  isStreamStarting() {
+    return this._ricStreamHandler.isStreamStarting();
+  }
+
   // Mark: Connection performance--------------------------------------------------------------------------
 
   parkmiller_next(seed: number) {

--- a/src/RICStreamHandler.ts
+++ b/src/RICStreamHandler.ts
@@ -113,6 +113,10 @@ export default class RICStreamHandler {
     }, 0);
   }
 
+  public isStreamStarting() {
+    return this._streamIsStarting;
+  }
+
   private async _streamAudioSend(
     streamName: string,
     targetEndpoint: string,

--- a/src/RICStreamHandler.ts
+++ b/src/RICStreamHandler.ts
@@ -49,6 +49,8 @@ export default class RICStreamHandler {
   private audioDuration = 0;
   private streamingEnded = false;
 
+  private _streamIsStarting = false;
+
   // soundFinishPoint timer
   private soundFinishPoint: NodeJS.Timeout | null = null;
 
@@ -61,6 +63,11 @@ export default class RICStreamHandler {
 
   // Start streaming audio
   streamAudio(streamContents: Uint8Array, clearExisting: boolean, audioDuration: number): void {
+    if (this._streamIsStarting){
+      RICLog.error(`Unable to start sound, previous stream is still starting`);
+      return;
+    }
+
     this.audioDuration = audioDuration;
     // Clear (if required) and add to queue
     if (clearExisting) {
@@ -93,6 +100,7 @@ export default class RICStreamHandler {
     if (stream === undefined) {
       return;
     }
+    this._streamIsStarting = true;
 
     // Send stream
     setTimeout(async () => {
@@ -100,6 +108,7 @@ export default class RICStreamHandler {
         this._streamAudioSend("audio.mp3", "streamaudio", RICStreamType.RIC_REAL_TIME_STREAM, stream.streamContents);
       } catch (error) {
         RICLog.error(`RICStreamHandler._handleStreamStart ${error}`);
+        this._streamIsStarting = false;
       }
     }, 0);
   }
@@ -127,6 +136,7 @@ export default class RICStreamHandler {
 
     // Send file start message
     if (await this._sendStreamStartMsg(streamName, targetEndpoint, streamType, streamContents)) {
+      this._streamIsStarting = false;
 
       // Send contents
       if (await this._sendStreamContents(streamContents)) {
@@ -135,6 +145,7 @@ export default class RICStreamHandler {
         await this._sendStreamEndMsg(this._streamID);
       }
     }
+    this._streamIsStarting = false;
 
     // Check if any more audio to play
     if (this._streamAudioQueue.length > 0) {


### PR DESCRIPTION
This addresses the issue where if the interface is spammed with `streamAudio()` function calls it will lead to BLE errors

This currently happens for example when a `Play sound` block is put inside a loop by itself

It would be advantageous if the MartyBlocks `Play sound` block waited for the streaming session to initialise before returning, that would also lead to a more consistent timing for code that follows