### PR TITLE
forcing disconnction/reconnection during OTAs

### DIFF
--- a/src/RICChannel.ts
+++ b/src/RICChannel.ts
@@ -16,6 +16,7 @@ export default interface RICChannel
     isConnected(): boolean;
     connect(locator: string | object): Promise<boolean>;
     disconnect(): Promise<void>;
+    getConnectedLocator(): string | object;
     setOnConnEvent(connEventFn: RICConnEventFn): void;
     setMsgHandler(ricMsgHandler: RICMsgHandler): void;
     sendTxMsg(msg: Uint8Array, sendWithResponse: boolean): Promise<boolean>;

--- a/src/RICChannelWebBLE.ts
+++ b/src/RICChannelWebBLE.ts
@@ -88,6 +88,11 @@ export default class RICChannelWebBLE implements RICChannel {
     }
   }
 
+  // Get connected locator
+  getConnectedLocator(): string | object {
+    return this._bleDevice || "";
+  }
+
   // Connect to a device
   async connect(locator: string | object): Promise<boolean> {
 

--- a/src/RICChannelWebSocket.ts
+++ b/src/RICChannelWebSocket.ts
@@ -53,6 +53,11 @@ export default class RICChannelWebSocket implements RICChannel {
     this._onConnEvent = connEventFn;
   }
 
+  // Get connected locator
+  getConnectedLocator(): string | object {
+    return this._webSocket;
+  }
+
   // Connect to a device
   async connect(locator: string | object): Promise<boolean> {
 

--- a/src/RICConnector.ts
+++ b/src/RICConnector.ts
@@ -110,8 +110,10 @@ export default class RICConnector {
       nonFirmwareElemTypes,
       appVersion,
       fileDownloader,
-      appUpdateURL
+      appUpdateURL,
+      this._ricChannel
     );
+    this._ricUpdateManager.setOnOTAReconnectCb(this.retrieveMartySystemInfo.bind(this));
   }
 
   setEventListener(onEventFn: RICEventFn): void {

--- a/src/RICUpdateManager.ts
+++ b/src/RICUpdateManager.ts
@@ -397,8 +397,8 @@ export default class RICUpdateManager {
     RICLog.debug(`fwUpdate: Waiting for restart. percComplete ${percComplete}, checkFwVersion: ${checkFwVersion}`);
     // manually disconnecting
     // but before we need to grab the device info so we can reconnect
-    let idToConnectTo: string = "";
-    let nameToConnectTo: string = "";
+    let idToConnectTo = "";
+    let nameToConnectTo = "";
     RICLog.debug("Disconnecting from BLE");
     if (this._ricChannel) {
       const deviceInfo: BluetoothDevice = this._ricChannel.getConnectedLocator() as BluetoothDevice;


### PR DESCRIPTION
Fixing OTA issue: During OTA marty restarts and the app waits until it picks up marty's signal again. This creates an issue where sometimes the app can't find marty and thus the update fails.

Fix: Forcing a "manual" reconnection during OTA by using marty's BLE address.