### PR TITLE
checking status bit before checking fault byte

### DIFF
--- a/src/RICConnector.ts
+++ b/src/RICConnector.ts
@@ -94,7 +94,7 @@ export default class RICConnector {
   private _onEventFn: RICEventFn | null = null;
 
   // RICServoFaultDetector for detecting servo faults
-  public ricServoFaultDetector: RICServoFaultDetector = new RICServoFaultDetector(this._ricMsgHandler);
+  public ricServoFaultDetector: RICServoFaultDetector = new RICServoFaultDetector(this._ricMsgHandler, this._ricStateInfo);
   
   constructor() {
     // Debug

--- a/src/RICROSSerial.ts
+++ b/src/RICROSSerial.ts
@@ -244,8 +244,6 @@ export class RICROSSerial {
     }
   }
 
-
-
   static extractSmartServos(buf: Uint8Array): ROSSerialSmartServos {
     // Each group of attributes for a servo is a fixed size
     const ROS_SMART_SERVOS_ATTR_GROUP_BYTES = 6;


### PR DESCRIPTION
In the ServoFaultDetector class, when we go through all the servos to see if there is any fault, we first check the status bit of the servo if it's enabled. If it is, we proceed to checking the fault byte