### PR TITLE
Catch error gracefully and continue if serial port is already open wh…

### DIFF
--- a/src/RICChannelWebSerial.ts
+++ b/src/RICChannelWebSerial.ts
@@ -92,7 +92,17 @@ export default class RICChannelWebSerial implements RICChannel {
         this._port = port;
       }
       // Connect
-      await this._port.open({ baudRate: 115200 });
+      try {
+        RICLog.info("opening port");
+        await this._port.open({ baudRate: 115200 });
+      } catch (err: any){
+        if (err.name == "InvalidStateError"){
+            RICLog.debug(`Opening port failed - already open ${err}`);
+        } else {
+            RICLog.error(`Opening port failed: ${err}`);
+            throw err;
+        }
+    }
 
       this._isConnected = true;
 


### PR DESCRIPTION
The changes addresse an intermittent bug that causes a failure to reconnect after the main fw update